### PR TITLE
fix: initialize as empty orderContents and orderContents_ids

### DIFF
--- a/facebookpixelinstaller.php
+++ b/facebookpixelinstaller.php
@@ -340,6 +340,8 @@ class Facebookpixelinstaller extends Module
         if(Tools::getValue('controller') === "search") {
             $search_str = Tools::getValue('s');
         }
+        $orderContents = array();
+        $orderContent_ids = array();
         if(Configuration::get('facebook_pixel_id') != '' && Configuration::get('facebook_pixel_active')) {
             $this->context->smarty->assign(
                 array(


### PR DESCRIPTION
these should mute useless spam in logs

	Warning: Undefined variable $orderContents in /home/naeboweh/public_html/modules/facebookpixelinstaller/facebookpixelinstaller.php on line 361
	Warning: Undefined variable $orderContent_ids in /home/naeboweh/public_html/modules/facebookpixelinstaller/facebookpixelinstaller.php on line 362